### PR TITLE
Experimental: Remove Tailwind from uikit library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -1049,12 +1049,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1142,16 +1142,10 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1163,6 +1157,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -1378,9 +1375,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1593,9 +1590,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1613,12 +1610,12 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -1844,12 +1841,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1915,15 +1915,12 @@
       "dev": true
     },
     "node_modules/jackspeak": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1964,12 +1961,15 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -2027,12 +2027,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -2246,6 +2246,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2309,13 +2315,10 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "5.0.0",
@@ -2369,9 +2372,9 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -2483,19 +2486,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/postcss-cli/node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
     },
     "node_modules/postcss-cli/node_modules/postcss-load-config": {
       "version": "5.1.0",
@@ -2683,29 +2673,26 @@
         }
       }
     },
-    "node_modules/postcss-load-config/node_modules/lilconfig": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/postcss-nested": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.11"
+        "postcss-selector-parser": "^6.1.1"
       },
       "engines": {
         "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
         "postcss": "^8.2.14"
@@ -2739,9 +2726,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-      "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -2881,17 +2868,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3280,31 +3270,29 @@
       }
     },
     "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3477,33 +3465,33 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
-      "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
+        "chokidar": "^3.6.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.3.0",
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.21.0",
-        "lilconfig": "^2.1.0",
-        "micromatch": "^4.0.5",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.1",
-        "postcss-nested": "^6.0.1",
-        "postcss-selector-parser": "^6.0.11",
-        "resolve": "^1.22.2",
-        "sucrase": "^3.32.0"
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -58,34 +58,33 @@
 </script>
 
 <main
-  class="p-20 bg-secondary h-screen overflow-y-auto"
   on:contextmenu|preventDefault
 >
-  <div class=" text-white flex flex-wrap flex-row gap-2">
-    <div class="grid grid-cols-4 gap-2 w-72 border border-black items-center">
+  <div class="main-container">
+    <div class="color-container">
       <span>Primary</span>
-      <div class="h-10 w-10 bg-primary border border-black" />
+      <div class="color bg-primary" />
 
       <span>Secondary</span>
-      <div class="h-10 w-10 bg-secondary border border-black" />
+      <div class="color bg-secondary" />
 
       <span>Error</span>
-      <div class="h-10 w-10 bg-error border border-black" />
+      <div class="color bg-error" />
 
       <span>Warning</span>
-      <div class="h-10 w-10 bg-warning border border-black" />
+      <div class="color bg-warning" />
 
       <span>Pick</span>
-      <div class="h-10 w-10 bg-pick border border-black" />
+      <div class="color bg-pick" />
 
       <span>Select</span>
-      <div class="h-10 w-10 bg-select border border-black" />
+      <div class="color bg-select" />
 
       <span>Commit</span>
-      <div class="h-10 w-10 bg-commit border border-black" />
+      <div class="color bg-commit" />
 
       <span>Unsaved Change</span>
-      <div class="h-10 w-10 bg-unsavedchange border border-black" />
+      <div class="color bg-unsavedchange" />
     </div>
     <div class="flex flex-col gap-2 w-72 border border-black">
       <span class="text-white">Block:</span>
@@ -337,3 +336,33 @@
     </div>
   </div>
 </main>
+
+<style>
+  main {
+    padding: 5rem;
+    background-color: rgba(42, 52, 57, 1.0);
+    height: 100vh;
+    overflow-y: auto;
+  }
+  div.main-container {
+    color: white;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    gap: 0.5rem;
+  }
+  div.color-container {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.5rem;
+    width: 18rem;
+    border: 1px solid black;
+    align-items: center;
+  }
+
+  div.color {
+    height: 2.5rem;
+    width: 2.5rem;
+    border: 1px solid black;
+  }
+</style>

--- a/src/lib/AtomicInput.svelte
+++ b/src/lib/AtomicInput.svelte
@@ -5,7 +5,6 @@
 
   export let inputValue = "";
   export let suggestions: { value: string; info: string }[] = [];
-  export let customClasses = "";
   export let placeholder = "";
   export let suggestionTarget: Element | undefined = undefined;
   export let validator = (text: string) => {
@@ -92,7 +91,7 @@
   let inputComponent;
 </script>
 
-<div class="{$$props.class} w-full relative">
+<div class="{$$props.class} container">
   <input
     bind:this={inputComponent}
     {disabled}
@@ -100,19 +99,14 @@
     on:focus={handleFocus}
     on:blur={handleBlur}
     on:suggestion-select={handleSuggestionSelected}
-    type="text"
     {placeholder}
-    class="{customClasses} w-full border
-        focus:neumorph focus:rounded-lg
-        {isError
-      ? 'border-error focus:outline-error'
-      : 'focus:border-select border-secondary'} bg-secondary text-white py-0.5 pl-2 rounded-none"
-    class:text-opacity-50={disabled}
+    class:error={isError}
+    class:disabled={disabled}
   />
 
-  <div class=" py-1">
+  <div class="info-value">
     {#if !focus && infoValue !== undefined}
-      <div class="{infoValue ? 'text-gray-500' : 'text-gray-600'} text-sm">
+      <div class="info-text">
         {infoValue}
       </div>
     {/if}
@@ -120,10 +114,46 @@
 </div>
 
 <style>
-  .neumorph {
+  div.container {
+    width: 100%;
+    position: relative;
+  }
+
+  input {
+    width: 100%;
+    border-width: 1px;
+    border-color: rgba(42, 52, 57, 1.0);
+    background-color: rgba(42, 52, 57, 1.0);
+    color: white;
+    padding-top: 0.125rem;
+    padding-bottom: 0.125rem;
+    padding-left: 0.5rem;
+    border-radius: 0px;
+  }
+  input:focus {
     box-shadow:
       -2px -2px 10px #242c30,
       2px 2px 10px #303c42;
+    border-radius: 0.5rem;
+    border-color: rgba(71, 87, 95, 1.0);
+  }
+  input.error {
+    border-color: rgba(220, 38, 38, 1.0);
+  }
+  input.error:focus {
+    outline-color: #DC2626;
+  }
+  input.disabled {
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  div.info-value {
+    padding: 0.25rem 0;
+  }
+  div.info-text {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    color: rgba(82, 82, 82, 1.0);
   }
 
   ::-webkit-scrollbar {

--- a/src/lib/AtomicSuggestions.svelte
+++ b/src/lib/AtomicSuggestions.svelte
@@ -25,21 +25,21 @@
 </script>
 
 <suggestions
-  class="flex w-full p-2"
+  class="container"
   class:hidden={suggestions.length === 0}
   bind:this={component}
   on:display={handleDisplay}
 >
-  <div class="w-full p-1 neumorph rounded-lg border border-select bg-secondary">
+  <div class="suggestion-list-container">
     <ul
-      class="scrollbar max-h-40 overflow-y-scroll pr-1 text-white cursor-pointer"
+      class="scrollbar suggestion-list"
     >
       {#each suggestions as suggestion}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
         <li
           on:mousedown={() => handleSuggestionSelected(suggestion.value)}
-          class="hover:bg-black p-1 pl-2"
+          class="suggestion"
         >
           {suggestion.info}
         </li>
@@ -49,9 +49,36 @@
 </suggestions>
 
 <style>
-  .neumorph {
+  suggestions.container {
+    display: flex;
+    width: 100%;
+    padding: 0.5rem;
+  }
+  suggestions.hidden {
+    display: none;
+  }
+  div.suggestion-list-container {
+    width: 100%;
+    padding: 0.25rem;
     box-shadow:
       -2px -2px 10px #242c30,
       2px 2px 10px #303c42;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(71, 87, 95, 1.0);
+    background-color: rgba(42, 52, 57, 1.0);
+  }
+  ul.suggestion-list {
+    max-height: 10rem;
+    overflow-y: scroll;
+    padding-right: 0.25rem;
+    color: white;
+    cursor: pointer;
+  }
+  li.suggestion {
+    padding: 0.25rem;
+    padding-left: 0.5rem;
+  }
+  li.suggestion:hover {
+    background-color: black;
   }
 </style>

--- a/src/lib/Block.svelte
+++ b/src/lib/Block.svelte
@@ -3,8 +3,19 @@
 </script>
 
 <div
-  class="py-4 border {border !== 'transparent' ? 'px-4' : ''} {'border-' +
-    border}"
+  class:transparent-block={border === "transparent"}
+  style:border-color={border}
 >
   <slot />
 </div>
+
+<style>
+  div {
+    padding: 1rem;
+    border-width: 1px;
+  }
+  .transparent-block {
+    padding-left: 0rem;
+    padding-right: 0rem;
+  }
+</style>

--- a/src/lib/BlockBody.svelte
+++ b/src/lib/BlockBody.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
 </script>
 
-<div class="text-white text-opacity-60 py-2">
+<div>
   <slot />
 </div>
+
+<style>
+  div {
+    color: rgba(255, 255, 255, 0.6);
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+</style>

--- a/src/lib/BlockColumn.svelte
+++ b/src/lib/BlockColumn.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
 </script>
 
-<div class="flex flex-col w-full gap-y-4 py-2">
+<div>
   <slot />
 </div>
+
+<style>
+  div {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    row-gap: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+</style>

--- a/src/lib/BlockRow.svelte
+++ b/src/lib/BlockRow.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
 </script>
 
-<div class="flex flex-row w-full gap-x-4 py-2">
+<div>
   <slot />
 </div>
+
+<style>
+  div {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    row-gap: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+</style>

--- a/src/lib/BlockTitle.svelte
+++ b/src/lib/BlockTitle.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
 </script>
 
-<div class="text-white py-2">
+<div>
   <slot />
 </div>
+
+<style>
+  div {
+    color: white;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+</style>

--- a/src/lib/ContextMenu.svelte
+++ b/src/lib/ContextMenu.svelte
@@ -61,16 +61,11 @@
 >
   <div
     bind:this={menu}
-    class="flex flex-col items-start bg-gray-900 text-white/80 border border-white/50 rounded absolute"
   >
     {#each items as item}
       {@const disabled = item.isDisabled ? item.isDisabled() : false}
       <button
-        class="text-white text-xs flex flex-row gap-2 {disabled
-          ? ''
-          : 'hover:bg-white/40 hover:text-white'} items-center whitespace-nowrap w-full px-2 py-2 text-left cursor-default"
-        class:opacity-75={!disabled}
-        class:opacity-25={disabled}
+        style:opacity={disabled ? 0.25 : 0.75}
         {disabled}
         on:click={() => handleItemClicked(item)}
       >
@@ -82,11 +77,11 @@
             iconPath={item.iconPath}
           />
         {/if}
-        <span class="flex-1">{item.text[0]}</span>
+        <span>{item.text[0]}</span>
         <!-- Spacer for alignment -->
         <span
-          class="invisible"
-          style="width: {maxLength - item.text[0].length}ch;"
+          style:width={`${maxLength - item.text[0].length}ch`}
+          style:visibility="hidden"
           >{item.text[0]}</span
         >
         <span>{item.text[1]}</span>
@@ -96,7 +91,32 @@
 </Popover>
 
 <style>
-  .flex-1 {
-    flex: 1;
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 0.25rem;
+    position: absolute;
+    color: rgba(255, 255, 255, 0.8);
+    background-color: rgb(23, 23, 23);
+  }
+
+  button {
+    color: white;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    align-items: center;
+    white-space: nowrap;
+    width: 100%;
+    padding: 0.5rem;
+    text-align: left;
+    cursor: default;
+  }
+  button:hover {
+    background-color: rgba(255, 255, 255, 0.4);
   }
 </style>

--- a/src/lib/MeltCheckbox.svelte
+++ b/src/lib/MeltCheckbox.svelte
@@ -32,18 +32,15 @@
 </script>
 
 <label
-  class="my-4 {style == 'box'
-    ? 'bg-black bg-opacity-10 border border-black border-opacity-20'
-    : ''} group flex text-white items-center cursor-pointer p-2"
+  class:checkbox-box={style === 'box'}
 >
-  <button {...$root} use:root class="">
+  <button {...$root} use:root>
     <div
-      class="relative flex items-center justify-center rounded border w-6 h-6"
+      class="checkbox-outer"
     >
       <div
-        class="{target
-          ? 'block'
-          : 'hidden'} absolute rounded-sm bg-white h-3 w-3"
+        style:display={target ? 'block' : 'none'}
+        class="checkbox-inner"
       />
     </div>
 
@@ -52,11 +49,55 @@
 
   {#if title}
     <div
-      class="pl-2 text-white group-hover:text-opacity-100 {target
-        ? 'text-opacity-100'
-        : 'text-opacity-80'}"
+      class:checkbox-title-selected={target}
+      class="checkbox-title"
     >
       {title}
     </div>
   {/if}
 </label>
+
+<style>
+  label {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    display: flex;
+    color: white;
+    align-items: center;
+    cursor: pointer;
+    padding: 0.5rem;
+  }
+  label:hover {
+    --title-text-opacity: 1.0;
+  }
+
+  .checkbox-box {
+    background-color: rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .checkbox-outer {
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 0.25rem;
+    margin: auto;
+    border: 1px solid white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .checkbox-inner {
+    width: 0.75rem;
+    height: 0.75rem;
+    background-color: white;
+    border-radius: 0.125rem;
+  }
+  .checkbox-title {
+    padding-left: 0.5rem;
+    color: rgba(255, 255, 255, var(--title-text-opacity, 0.8));
+  }
+  .checkbox-title-selected {
+    --title-text-opacity: 1.0;
+  }
+</style>

--- a/src/lib/MeltCombo.svelte
+++ b/src/lib/MeltCombo.svelte
@@ -152,8 +152,8 @@
   }
 </script>
 
-<div class="flex flex-col relative" class:flex-grow={size === "full"}>
-  <div class="flex flex-col gap-1">
+<div class="container" class:flex-grow={size === "full"}>
+  <div class="content">
     {#if title?.length > 0}
       <label class="text-white text-sm truncate items-center">
         {title}
@@ -172,11 +172,8 @@
           on:click|stopPropagation={() => {
             open.set(true);
           }}
-          class="trigger w-full flex flex-row border {isError && !disabled
-            ? 'border-error'
-            : 'border-black'} p-2 {disabled
-            ? 'bg-black/50 text-white/40'
-            : 'bg-black/25 text-white'} mt-1"
+          class:error={isError && !disabled}
+          class:disabled={disabled}
           {placeholder}
           {disabled}
         />
@@ -197,11 +194,8 @@
         on:click|stopPropagation={() => {
           open.set(true);
         }}
-        class="trigger w-full flex flex-row border {isError && !disabled
-          ? 'border-error'
-          : 'border-black'} p-2 {disabled
-          ? 'bg-black/50 text-white/40'
-          : 'bg-black/25 text-white'}"
+        class:error={isError && !disabled}
+        class:disabled={disabled}
         {placeholder}
         {disabled}
       />
@@ -222,7 +216,7 @@
           <option
             {...$close}
             use:close
-            class="cursor-pointer truncate hover:bg-white/40 flex w-full px-2 py-1 hover:text-white"
+            class="suggestion"
             on:click={() => selected.set(suggestion)}>{suggestion.info}</option
           >
         {/each}
@@ -230,18 +224,92 @@
     </div>
   {/if}
 
-  <div class="text-white/60 text-sm truncate" class:hidden={!valueInfoEnabled}>
+  <div class="info-value" style:display={valueInfoEnabled ? "visible" : "none"}>
     {infoValue}
   </div>
 </div>
 
-<style lang="postcss">
-  .menu {
-    @apply bg-gray-900 text-white/80 border border-white/50 rounded z-40 max-h-32 flex flex-col overflow-y-auto;
-    @apply min-w-[8%] w-fit max-w-[13%] !important;
+<style>
+  div.container {
+    display: flex;
+    flex-direction: column;
+    position: relative;
   }
-
-  .trigger {
-    @apply cursor-auto outline-none !important;
+  div.flex-grow {
+    flex-grow: 1
+  }
+  div.content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem
+  }
+  label {
+    color: white;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    align-items: center;
+  }
+  input {
+    cursor: auto;
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    border-width: 1px;
+    padding: 0.5rem;
+    border-color: rgba(0, 0, 0, 1.0);
+    color: white;
+    background-color: rgba(0, 0, 0, 0.25);
+    margin-top: 0.25rem;
+  }
+  input.error {
+    border-color: rgba(220, 38, 38, 1.0);
+  }
+  input.disabled {
+    background-color: rgba(0, 0, 0, 0.5);
+    color: rgba(255, 255, 255, 0.4);
+  }
+  .menu {
+    background-color: rgba(23, 23, 23, 1);
+    color: rgba(255, 255, 255, 0.8);
+    border-width: 1px;
+    border-color: rgba(255, 255, 255, 0.5);
+    border-radius: 0.25rem;
+    z-index: 40;
+    max-height: 8rem;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    min-width: 8%;
+    width: fit-content;
+    max-width: 13%;
+  }
+  option.suggestion {
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: flex;
+    width: 100%;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+  }
+  option.suggestion:hover {
+    background-color: rgba(255, 255, 255, 0.4);
+    color: white;
+  }
+  div.info-value {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 </style>

--- a/src/lib/MeltRadio.svelte
+++ b/src/lib/MeltRadio.svelte
@@ -52,55 +52,47 @@
 <div
   {...$root}
   use:root
-  class="text-white overflow-visible
-    {size == 'full' && orientation == 'horizontal' ? 'w-full' : ''}
-    {orientation === 'vertical'
-    ? 'grid grid-flow-row my-2 gap-4'
-    : 'grid grid-flow-col'}
-    {style === 'button' ? 'gap-4' : ''}
-    {style !== 'button' && orientation !== 'vertical'
-    ? 'border border-black border-opacity-20 bg-black bg-opacity-10'
-    : ''} py-2"
+  class:container-full={size == 'full' && orientation == 'horizontal'}
+  class:container-vertical={orientation === 'vertical'}
+  class:container-button={style === 'button'}
+  class:radio-border={style !== 'button' && orientation !== 'vertical'}
+  class="container"
 >
   {#each options as option}
     <!-- Convert value to string in case it was originally boolean -->
     {@const value = option.value.toString()}
     {@const title = option.title}
     <label
-      class="
-    {orientation === 'vertical'
-        ? 'border border-black border-opacity-20 bg-black bg-opacity-10 py-2'
-        : ''} 
-      group cursor-pointer flex items-center {style !== 'button' ? 'px-2' : ''}"
+      class:radio-border={orientation === 'vertical'}
+      class:vertical-padding={orientation === 'vertical'}
+      class:horizontal-padding={style !== 'button'}
+      class="row"
     >
       {#if style === "radio"}
         <button {...$item(value)} use:item id={title}>
           <div
-            class="relative flex items-center justify-center rounded-full border w-6 h-6 mr-3"
+            class="style-radio"
           >
             <div
-              class="{$isChecked(value)
-                ? 'block'
-                : 'hidden'} absolute rounded-full bg-white h-3 w-3"
+              style:display={$isChecked(value) ? 'block' : 'none'}
+              class="style-radio-inside"
             />
           </div>
         </button>
-
-        <span id="{title}-label">{title}</span>
+        <span>{title}</span>
       {/if}
       {#if style === "button"}
         <button
           {...$item(value)}
           use:item
           id={title}
-          class="relative px-2 py-1 w-full rounded bg-black bg-opacity-10 border border-black border-opacity-40"
-          class:bg-opacity-60={$isChecked(value)}
-          class:hover:bg-opacity-40={!$isChecked(value)}
+          class="style-button"
+          class:selected={$isChecked(value)}
         >
           {#if typeof title !== "undefined"}
-            <span id="{title}-label">{title}</span>
+            <span>{title}</span>
           {:else}
-            <span class="invisible">N/A</span>
+            <span style:visibility="hidden">N/A</span>
           {/if}
           <slot name="item" {value} />
         </button>
@@ -108,3 +100,73 @@
     </label>
   {/each}
 </div>
+
+<style>
+  div.container {
+    color: white;
+    overflow: visible;
+    display: grid;
+    grid-auto-flow: column;
+    padding: 0.5rem 0;
+  }
+  div.container-full {
+    width: 100%;
+  }
+  div.container-vertical {
+    grid-auto-flow: row;
+    margin: 0.5rem 0;
+    gap: 1rem;
+  }
+  div.container-button {
+    gap: 1rem;
+  }
+  .radio-border {
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+  label.row{
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+  }
+  label.vertical-padding {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem
+  }
+  label.horizontal-padding {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  div.style-radio {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border-width: 1px;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 0.75rem;
+  }
+  div.style-radio-inside {
+    position: absolute;
+    border-radius: 9999px;
+    background-color: white;
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+  button.style-button {
+    position: relative;
+    padding: 0.25rem 0.5rem;
+    width: 100%;
+    border-radius: 0.25rem;
+    background-color: rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.4);
+  }
+  button.style-button:hover {
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+  button.style-button.selected {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+</style>

--- a/src/lib/MeltSelect.svelte
+++ b/src/lib/MeltSelect.svelte
@@ -52,30 +52,27 @@
   }
 </script>
 
-<div class="flex flex-col gap-1" class:flex-grow={size === "full"}>
+<div class="container flex-grow" class:container-grow={size === "full"}>
   <button
     {...$trigger}
     use:trigger
-    class="w-full flex flex-row border border-black p-2"
+    class="select"
   >
-    <div class="flex flex-grow truncate">{$selectedLabel || " "}</div>
-    <div class="flex">&#9660;</div>
+    <span>{$selectedLabel || " "}</span>
+    <span>&#9660;</span>
   </button>
   {#if $open}
     <div
       {...$menu}
       use:menu
-      class="bg-gray-900 text-white/80 border border-white/50 rounded z-40"
+      class="menu"
     >
       {#each options as item}
         <div
           {...$option({ value: item.value, label: item.title })}
           use:option
-          class="cursor-pointer hover:bg-white/40 p-2 hover:text-white {$isSelected(
-            item.value,
-          )
-            ? 'bg-white/10'
-            : ' '}"
+          class="option"
+          class:option-selected={$isSelected(item.value)}
         >
           {item.title}
         </div>
@@ -83,3 +80,40 @@
     </div>
   {/if}
 </div>
+
+<style>
+  div.container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  div.container-grow {
+    flex-grow: 1;
+  }
+  button.select {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    border: 1px solid black;
+    padding: 0.5rem;
+  }
+  .menu {
+    background-color: rgba(23, 23, 23, 1);
+    color: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 0.25rem;
+    z-index: 40;
+  }
+  div.option {
+    cursor: pointer;
+    padding: 0.5rem;
+  }
+  div.option:hover {
+    background-color: rgba(255, 255, 255, 0.4);
+    color: rgba(255, 255, 255, 1);
+  }
+  div.option-selected {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+</style>

--- a/src/lib/MeltSlider.svelte
+++ b/src/lib/MeltSlider.svelte
@@ -33,17 +33,49 @@
   // }
 </script>
 
-<span {...$root} use:root class="relative flex w-[200px] items-center h-[26px]">
-  <span class="block h-[3px] w-full bg-white rounded-full h-[8px]">
+<span {...$root} use:root class="container">
+  <span class="range-full">
     <span
       {...$range}
       use:range
-      class="h-[3px] bg-neutral-500 rounded-full h-[8px]"
+      class="range-selected"
     />
   </span>
   <span
     {...$thumbs[0]}
     use:thumbs
-    class="block h-5 w-5 rounded-full bg-neutral-500 focus:ring-2 focus:ring-black/40"
+    class="thumb"
   />
 </span>
+
+<style>
+  span.container {
+    position: relative;
+    display: flex;
+    width: 200px;
+    align-items: center;
+    height: 26px;
+  }
+  span.range-full {
+    display: block;
+    width: 100%;
+    background-color: white;
+    border-radius: 9999px;
+    height: 8px;
+  }
+  span.range-selected {
+    height: 8px;
+    background-color: rgba(115, 115, 115, 1);
+    border-radius: 9999px;
+  }
+  span.thumb {
+    display: block;
+    height: 1.25rem;
+    width: 1.25rem;
+    border-radius: 9999px;
+    background-color: rgba(115, 115, 115, 1);
+  }
+  span.thumb:focus {
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 1);
+  }
+</style>

--- a/src/lib/MoltenButton.svelte
+++ b/src/lib/MoltenButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let click;
-  export let border: string = "black";
+  export let border: string = "#0006";
   export let title: string;
 </script>
 
@@ -11,8 +11,19 @@
     }
     click();
   }}
-  class="px-8 py-1 rounded bg-black bg-opacity-20 border border {'border-' +
-    border} border-opacity-40 hover:bg-opacity-60"
+  style:border-color={border}
 >
   {title}
 </button>
+
+<style>
+  button {
+    padding: 0.25rem 2rem;
+    border-radius: 0.25rem;
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px;
+  }
+  button:hover {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+</style>

--- a/src/lib/MoltenInput.svelte
+++ b/src/lib/MoltenInput.svelte
@@ -49,9 +49,25 @@
 <input
   bind:this={input}
   {disabled}
-  class="w-full flex px-2 py-2 text-white text-opacity-80 flex-grow bg-black/25 border border-black border-opacity-20 focus:border-green-500 focus:outline-none"
   bind:value={target}
   on:change={handleChange}
   on:click|stopPropagation
   on:keydown={handleKeydown}
 />
+
+<style>
+  input {
+    width: 100%;
+    display: flex;
+    padding: 0.5rem;
+    color: rgba(255, 255, 255, 0.8);
+    flex-grow: 1;
+    background-color: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+  input:focus{
+    border-color: rgba(34, 197, 94, 1.0);
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+</style>

--- a/src/lib/MoltenPushButton.svelte
+++ b/src/lib/MoltenPushButton.svelte
@@ -11,7 +11,7 @@
   let showPopup: boolean = false;
 </script>
 
-<container class="relative" class:w-full={snap === "full"}>
+<container class:width-full={snap === "full"}>
   <button
     class:selected
     on:click={() => {
@@ -31,7 +31,7 @@
     {disabled}
     class="{disabled
       ? `${style}-disabled`
-      : `${style}-enabled`} rounded focus:outline-none truncate py-1"
+      : `${style}-enabled`}"
     class:px-4={ratio === "normal"}
     class:px-1={ratio === "box"}
     class:w-full={snap === "full"}
@@ -47,24 +47,72 @@
 </container>
 
 <style>
+  container {
+    position: relative;
+  }
+  container.width-full {
+    width: 100%;
+  }
+
+  button {
+    border-radius: 0.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.25rem;
+  }
+  button.w-full {
+    width: 100%;
+  }
+  button.w-fit {
+    width: fit-content;
+  }
+  button.px-4 {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  button:focus {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
   .normal-enabled {
-    @apply text-gray-50 bg-black bg-opacity-10 border border-black border-opacity-40 hover:bg-opacity-40;
+    color: rgba(250, 250, 250, 0.5);
+    background-color: rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.4);
+  }
+  .normal-enabled:hover {
+    background-color: rgba(0, 0, 0, 0.4)
   }
   .normal-disabled {
-    @apply text-gray-50/25 bg-black/25 bg-opacity-10 border border-black/25 border-opacity-40;
+    color: rgba(250, 250, 250, 0.25);
+    background-color: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(0, 0, 0, 0.25);
   }
 
   .outlined-enabled {
-    @apply border hover:bg-commit-saturate-20 text-white border-commit-saturate-10 hover:border-commit-desaturate-10;
+    border: 1px solid rgba(0, 164, 130, 1);
+    color: white;
+  }
+  .outlined-enabled:hover {
+    background-color: rgba(0, 111, 83, 1.0);
+    border-color: rgba(27, 164, 135)
   }
   .outlined-disabled {
-    @apply border text-white border-commit-saturate-10 bg-opacity-50 text-opacity-50;
+    border: 1px solid rgba(0, 163, 130, 1.0);
+    color: rgba(255, 255, 255, 0.5);
   }
 
   .accept-enabled {
-    @apply text-white bg-commit hover:bg-commit-saturate-20;
+    color: white;
+    background-color: rgba(11, 164, 132, 1.0)
+  }
+  .accept-enabled:hover {
+    background-color: rgba(0, 111, 83, 1.0)
   }
   .accept-disabled {
-    @apply text-white bg-commit bg-opacity-50 text-opacity-50;
+    color: rgba(255, 255, 255, 0.5);
+    background-color: rgba(11, 164, 132, 0.5);
   }
 </style>

--- a/src/lib/MoltenTooltip.svelte
+++ b/src/lib/MoltenTooltip.svelte
@@ -178,16 +178,16 @@
     on:mouseenter={handleMouseEnter}
     on:mouseleave={handleMouseLeave}
     on:click={handleClick}
-    class="{$$props.class} tooltip-bg cursor-default flex flex-col relative rounded-md z-[99]"
+    class="{$$props.class} tooltip-container"
     transition:fade|global={{
       duration: instant ? 0 : duration, //Make it instant when explicitly clicked
     }}
   >
-    <div class="flex flex-col w-full h-full" class:gap-2={buttons.length > 0}>
+    <div class="tooltip-container-content" class:tooltip-gap-2={buttons.length > 0}>
       {#if typeof component === "undefined"}
         <div
-          class="text-white text-left font-normal"
-          class:whitespace-nowrap={nowrap}
+          class="tooltip-container-text"
+          class:tooltip-whitespace-nowrap={nowrap}
         >
           {text}
         </div>
@@ -195,7 +195,7 @@
         <svelte:component
           this={component.object}
           {...component.props}
-          class="z-10"
+          class="tooltip-container-component"
           on:event={interceptEvent}
         />
       {/if}
@@ -203,7 +203,7 @@
       {#if showbuttons}
         <div
           transition:slide|global={{ duration: instant ? 0 : 100 }}
-          class="gap-2 flex flex-row w-full"
+          class="tooltip-container-buttons"
         >
           {#each buttons as button}
             <MoltenPushButton
@@ -225,21 +225,59 @@
     transition:fade|global={{
       duration: instant ? 0 : duration,
     }}
-    class="absolute"
+    class="tooltip-absolute"
     id="arrow"
     data-popper-arrow
   >
-    <div class="absolute" id="arrow_face" />
+    <div class="tooltip-absolute" id="arrow_face" />
   </div>
 </Popover>
 
 <style global>
-  :root {
+  div.tooltip-container {
     --tooltip-bg-color: rgba(14, 20, 24, 0.8);
+    background-color: var(--tooltip-bg-color);
+    cursor: default;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    border-radius: 0.375rem;
+    z-index: 99;
+  }
+  
+  div.tooltip-container-content {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
   }
 
-  .tooltip-bg {
-    background-color: var(--tooltip-bg-color);
+  div.tooltip-gap-2 {
+    gap: 0.5rem;
+  }
+
+  div.tooltip-container-text {
+    color: white;
+    text-align: left;
+    font-weight: 400;
+  }
+  div.tooltip-whitespace-nowrap {
+    white-space: nowrap;
+  }
+
+  .tooltip-container-component {
+    z-index: 10;
+  }
+
+  div.tooltip-container-buttons {
+    gap: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+  }
+
+  div.tooltip-absolute {
+    position: absolute;
   }
 
   .svelte-easy-popover[data-popper-placement^="top"] > #arrow {
@@ -288,5 +326,5 @@
     border-bottom: 10px solid transparent;
 
     border-right: 10px solid var(--tooltip-bg-color);
-  }
+  }  
 </style>

--- a/src/lib/SvgIcon.svelte
+++ b/src/lib/SvgIcon.svelte
@@ -7,7 +7,10 @@
   export let fill: string | undefined = undefined;
 </script>
 
-<svg style="width: {width}px; height: {height}px; fill: {fill};">
+<svg
+  style:fill
+  style:width={`${width}px`}
+  style:height={`${height}px`}>
   <g>
     {#if iconMap[iconPath]}
       {@html iconMap[iconPath]}

--- a/src/lib/Tree.svelte
+++ b/src/lib/Tree.svelte
@@ -35,20 +35,17 @@
     {...$item({ id: child.id, hasChildren: true })}
     use:item
     on:click={() => toggleExpand(child.id, level, $isExpanded(child.id))}
-    class="flex items-center w-full"
   >
     <slot name="folder" {level} {child} isExpanded={$isExpanded(child.id)} />
   </button>
 
   {#if $isExpanded(child.id)}
     <div
-      class="flex flex-col"
-      class:max-h-full={level === 0}
-      class:overflow-y-scroll={level === 0}
-      class:pr-1={level === 0}
+      class="subtree"
+      class:root-subtree={level === 0}
     >
       {#if child.children && child.children.length > 0}
-        <div {...$group({ id: child.id })} use:group class="pl-4">
+        <div {...$group({ id: child.id })} use:group class="subtree-child">
           <svelte:self treeItems={child.children} level={level + 1}>
             <svelte:fragment slot="folder" let:level let:child let:isExpanded>
               <slot name="folder" {level} {child} {isExpanded} />
@@ -67,3 +64,23 @@
     </div>
   {/if}
 {/each}
+
+<style>
+  button {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+  div.subtree {
+    display: flex;
+    flex-direction: column;
+  }
+  div.root-subtree {
+    max-height: 100%;
+    overflow-y: scroll;
+    padding-right: 0.25rem;
+  }
+  div.subtree-child {
+    padding-left: 1rem;
+  }
+</style>


### PR DESCRIPTION
As described [here](https://github.com/intechstudio/profile-cloud/issues/122#issuecomment-2778158027), Tailwind is not equipped to handle different projects generating their own css files and then merging them into a single css file. Originally, end users (profile-cloud and grid-editor) were configured to search for classes in uikit library as well, which while cumbersome, worked. Later on, generation of css classes were separated and moved into uikit, and uikit-s css file was imported into the end users css file, which caused the linked issue.

This PR is the logical next step in this thinking by removing Tailwind from the uikit library, using instead Svelte component styles and `class`/`style` directives. Tailwind only remains to provide the basic css overrides for the hosted application.

OPEN QUESTIONS: How to handle brand colors nicely with pure CSS? Global variables, color mix?